### PR TITLE
Fixed crash when file content of node internal code is read

### DIFF
--- a/src/Filters/exception.filter.ts
+++ b/src/Filters/exception.filter.ts
@@ -18,6 +18,9 @@ export class ExceptionFilter extends BaseExceptionFilter {
 	}
 
 	catch(exception: any, host: ArgumentsHost) {
+		if (host.getType() != 'http') {
+			return;
+		}
 		const request = host.switchToHttp().getRequest()
 		const response = host.switchToHttp().getResponse()
 

--- a/src/Services/Resolver/stack-resolver.ts
+++ b/src/Services/Resolver/stack-resolver.ts
@@ -15,7 +15,7 @@ export class StackResolverService {
 
 		await errorStack.map(async (_stack: any, index: string | number) => {
 			// Resolve the exception line and add it to stack object as property.
-			const data = fs.readFileSync(errorStack[index].fileName, 'utf-8')
+			const data = fs.existsSync(errorStack[index].fileName) ? fs.readFileSync(errorStack[index].fileName, 'utf-8') : '';
 			const lines = data.split(/\r?\n/);
 			errorStack[index].codeRaw = lines.slice((errorStack[index].lineNumber - 16) >= 0 ? errorStack[index].lineNumber - 16 : 0, errorStack[index].lineNumber + 15)
 


### PR DESCRIPTION
Fixed crash when file content of node internal code is read.

When node-internal code is part of the stack, there is no file to read the source code from. This causes the process to crash. I added code to check for file existence (which could be done better).

Changed exception filter to ignore non-http requests.

Trying to handle exceptions that are not originated from an http request causes a crash. I added a safe-guard. Generating a website for non-http requests is senseless anyways.


